### PR TITLE
i18nを実装し、多言語対応させた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'bootsnap', require: false
 # Authentication
 gem 'sorcery'
 
+gem 'rails-i18n', '~> 7.0.0'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -328,6 +331,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  rails-i18n (~> 7.0.0)
   rubocop
   rubocop-capybara
   rubocop-rails

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -10,10 +10,10 @@
         <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
         <%= f.password_field :password, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500" %>
       </div>
-      <%= f.submit "ログイン", class: "w-full py-2 px-4 bg-blue-600 text-white font-semibold rounded-md shadow hover:bg-blue-700" %>
+      <%= f.submit class: "w-full py-2 px-4 bg-blue-600 text-white font-semibold rounded-md shadow hover:bg-blue-700" %>
     <% end %>
     <div class="text-center mt-4">
-      <%= link_to '登録ページへ', new_user_path, class: "text-blue-600 hover:underline" %>
+      <%= link_to t('.to_register_page'), new_user_path, class: "text-blue-600 hover:underline" %>
     </div>
   </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -18,10 +18,10 @@
         <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
         <%= f.password_field :password_confirmation, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500" %>
       </div>
-      <%= f.submit "登録", class: "w-full py-2 px-4 bg-blue-600 text-white font-semibold rounded-md shadow hover:bg-blue-700" %>
+      <%= f.submit class: "w-full py-2 px-4 bg-blue-600 text-white font-semibold rounded-md shadow hover:bg-blue-700" %>
     <% end %>
     <div class="text-center mt-4">
-      <%= link_to 'ログインページへ', login_path, class: "text-blue-600 hover:underline" %>
+      <%= link_to t('.to_login_page'), login_path, class: "text-blue-600 hover:underline" %>
     </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module Myapp
       g.helper false
       g.test_framework nil
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        name: 名前
+        password: パスワード
+        password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  user_sessions:
+    new:
+      title: ログイン
+      to_register_page: 登録ページへ
+  users:
+    new:
+      title: ユーザー登録
+      to_login_page: ログインページへ


### PR DESCRIPTION

概要
アプリケーションに国際化（i18n）を実装し、複数言語に対応させました。これにより、ユーザーはアプリケーションの表示言語を選択できるようになります。

変更点
i18nの設定ファイルを追加

config/locales フォルダに言語別の翻訳ファイルja.ymlを追加しました。
ビューのテキストをi18n対応