### PR TITLE
投稿作成機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'rails-i18n', '~> 7.0.0'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rakuten_web_service'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rakuten_web_service (1.13.2)
+      json (~> 2.3)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -335,6 +337,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n (~> 7.0.0)
+  rakuten_web_service
   rubocop
   rubocop-capybara
   rubocop-rails

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -2,4 +2,39 @@ class BoardsController < ApplicationController
   def index
     @boards = Board.includes(:user)
   end
+  def new
+    @board = Board.new
+  end
+
+  def create
+    @board = current_user.boards.build(board_params)
+    if @board.save
+      redirect_to boards_path, success: t('defaults.flash_message.created', item: Board.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: Board.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def search_gadgets
+    keyword = params[:keyword]
+    items = RakutenWebService::Ichiba::Item.search(keyword: keyword, genreId: '100240', hits: 10) # 100240はガジェットのジャンルID
+    
+    @gadgets = items.map do |item|
+      {
+        title: item['itemName'],
+        image_url: item['mediumImageUrls'].first['imageUrl'],
+        item_url: item['itemUrl'],
+        price: item['itemPrice']
+      }
+    end
+  
+    render json: @gadgets
+  end
+end
+
+private
+
+def board_params
+  params.require(:board).permit(:title, :body)
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, success: t('users.create.success')
+      auto_login(@user)
+      redirect_to boards_path, success: t('users.create.success')
     else
       flash.now[:danger] = t('users.create.failure')
       render :new, status: :unprocessable_entity

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,0 +1,51 @@
+<div class="container mx-auto">
+  <div class="flex justify-center">
+    <div class="w-full max-w-lg">
+      <h1 class="text-2xl font-bold mb-4"><%= t('.title') %></h1>
+      <%= form_with model: @board, class: "new_board" do |f| %>
+        <div class="mb-4">
+          <%= f.label :title, class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_field :title, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring focus:ring-blue-500" %>
+        </div>
+        <div class="mb-4">
+          <%= f.label :body, class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_area :body, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring focus:ring-blue-500", rows: "10" %>
+        </div>
+        
+<!-- ガジェット検索フォームの追加 -->
+<div class="mb-4">
+  <%= f.label :gadget_search, "ガジェット検索", for: "keyword" %>
+  <%= text_field_tag :keyword, nil, id: "keyword", class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring focus:ring-blue-500", autocomplete: "off" %>
+  <%= button_tag "検索", type: :button, id: "search-button", class: "mt-2 w-full px-4 py-2 bg-blue-500 text-white font-semibold rounded-md hover:bg-blue-600" %>
+</div>
+
+        <div id="result" class="mt-4"></div> <!-- 結果を表示する場所 -->
+
+        <%= f.submit nil, class: "w-full px-4 py-2 bg-blue-500 text-white font-semibold rounded-md hover:bg-blue-600" %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<script>
+document.getElementById('search-button').addEventListener('click', function() {
+  const keyword = document.querySelector('input[name="keyword"]').value;
+  fetch(`/search_gadgets?keyword=${encodeURIComponent(keyword)}`)
+    .then(response => response.json())
+    .then(data => {
+      const resultContainer = document.getElementById('result');
+      resultContainer.innerHTML = ''; // 以前の結果をクリア
+
+      data.forEach(gadget => {
+        const item = document.createElement('div');
+        const image = document.createElement('img'); // 新しいimg要素を作成
+
+        item.textContent = gadget.title; // ガジェットの名前を表示
+        image.src = gadget.image_url; // img要素のsrc属性にガジェットの画像URLを設定
+
+        item.appendChild(image); // img要素をdiv要素に追加
+        resultContainer.appendChild(item); // div要素を結果のコンテナに追加
+      });
+    });
+});
+</script>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,13 +5,13 @@
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
-        <li><%= link_to 'Timeline', boards_path %></li>
+        <li><%= link_to '投稿一覧', boards_path %></li>
         <li>
           <details>
             <summary>My Gadgets</summary>
             <ul class="bg-base-100 rounded-t-none p-2">
-              <li><%= link_to 'Login',login_path %></li>
-              <li><%= link_to 'SignUp',new_user_path %></li>           
+              <li><%= link_to 'ログイン',login_path %></li>
+              <li><%= link_to 'ユーザー登録',new_user_path %></li>           
             </ul>
           </details>
         </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,13 +5,14 @@
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
-        <li><%= link_to 'Timeline', boards_path %></li>
+        <li><%= link_to '投稿一覧', boards_path %></li>
+        <li><%= link_to '投稿する', new_board_path %></li>
         <li>
           <details>
-            <summary>My Page</summary>
+            <summary>マイページ</summary>
             <ul class="bg-base-100 rounded-t-none p-2">
-              <li><a>My Desk</a></li>
-              <li><%= link_to 'Logout', logout_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしてもよろしいですか？" }   %></li>
+              <li><a>〇〇'sガジェット</a></li>
+              <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしてもよろしいですか？" }   %></li>
             </ul>
           </details>
         </li>

--- a/config/initializers/rakuten_web_service.rb
+++ b/config/initializers/rakuten_web_service.rb
@@ -1,0 +1,6 @@
+require 'rakuten_web_service'
+
+RakutenWebService.configure do |c|
+  c.application_id = '1094189325186609229' # ここに取得したAPIキーを入力
+  c.affiliate_id = '3f502970.f7c07a9d.3f502971.ca92bfee'     # 任意でアフィリエイトIDも指定可能
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -2,6 +2,8 @@ ja:
   defaults:
     flash_message:
       require_login: ログインしてください
+      created: 登録しました
+      not_created: 登録に失敗しました
   helpers:
     submit:
       create: 登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
   root 'static_pages#top'
   resources :users, only: %i[new create]
-  resources :boards, only: %i[index]
+  resources :boards, only: %i[index new create]
   
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+  get 'search_gadgets', to: 'boards#search_gadgets'
 end


### PR DESCRIPTION
概要:
投稿作成機能を実装しました。ユーザーが投稿を作成し、ガジェットに関する情報を共有できるようになりました。
楽天APIを利用して、ガジェットを検索し、検索結果から選択したガジェットを投稿に含めることができる機能を追加しました。
変更点:
BoardsController:

create アクションを追加し、ユーザーが新しい投稿を作成できるようにしました。
search_gadgets アクションを追加し、楽天APIを使用してガジェットを検索し、JSON形式で結果を返す機能を実装しました。
ビュー (views/boards/new.html.erb):

投稿作成フォームにガジェット検索フォームを追加しました。
検索結果を表示するためのUIを追加しました。
JavaScript:

楽天APIから取得したガジェットの検索結果を表示するためのスクリプトを追加しました。
検索結果からガジェットを選択できるようにしました。
スタイル:

ガジェット検索結果の表示を調整し、ユーザーが見やすいように改善しました。