### PR TITLE
image_tagの修正

### DIFF
--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full lg:w-1/3 mb-3">
   <div id="board-id-<%= board.id %>">
     <div class="bg-white shadow-md rounded-lg overflow-hidden">
-      <%= image_tag board.board_image_url, class: "w-full h-48 object-cover" %>
+      <%= image_tag board.board_image_url.presence || 'board_placeholder.png', class: "w-full h-48 object-cover" %>
       <div class="p-4">
         <div class="flex items-center justify-between">
           <h4 class="text-lg font-semibold">


### PR DESCRIPTION
概要
このPRでは、画像表示の際に、画像のURLが存在しない場合にデフォルトの画像を表示するように修正した。

変更点
image_tagメソッドの引数を修正。
board.board_image_urlが存在しない場合に、board_placeholder.pngを表示するようにした。
これにより、画像がないときでもエラーが出ず、常に何らかの画像が表示されるようになる。
