### PR TITLE
MiniMagickを削除してRMagickを導入した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,9 +54,9 @@ gem 'rails-i18n', '~> 7.0.0'
 # upload
 gem 'aws-sdk-s3', require: false
 gem 'carrierwave', '~> 3.0'
-gem 'mini_magick'
 gem 'fog-aws'
 gem "image_processing"
+gem 'rmagick' 
 
 # environment variables
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,11 +251,13 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    observer (0.1.2)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.8)
+    pkg-config (1.5.6)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -310,6 +312,9 @@ GEM
     reline (0.5.10)
       io-console (~> 0.5)
     rexml (3.3.7)
+    rmagick (6.0.1)
+      observer (~> 0.1)
+      pkg-config (~> 1.4)
     rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -412,11 +417,11 @@ DEPENDENCIES
   image_processing
   jbuilder
   jsbundling-rails
-  mini_magick
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n (~> 7.0.0)
+  rmagick
   rubocop
   rubocop-capybara
   rubocop-rails

--- a/app/uploaders/board_image_uploader.rb
+++ b/app/uploaders/board_image_uploader.rb
@@ -1,5 +1,5 @@
 class BoardImageUploader < CarrierWave::Uploader::Base
-  include CarrierWave::MiniMagick # 画像サイズ調整のためにMiniMagickをinclude
+  include CarrierWave::RMagick # 画像サイズ調整のためにMiniMagickをinclude
   if Rails.env.production? # 本番環境の場合はS3に保存
     storage :fog
   else
@@ -14,7 +14,7 @@ class BoardImageUploader < CarrierWave::Uploader::Base
     ActionController::Base.helpers.asset_path('board_placeholder.png')  # 画像がない場合のデフォルト画像
   end
 
-  # process resize_to_fit: [400, 400] # 画像サイズの上限を400x400にする
+  process resize_to_fit: [400, 400] # 画像サイズの上限を400x400にする
 
   def extension_allowlist # 画像の拡張子を許可
     %w[jpg jpeg gif png]

--- a/config/initializers/minimagick.rb
+++ b/config/initializers/minimagick.rb
@@ -1,3 +1,0 @@
-MiniMagick.configure do |config|
-  config.cli = :imagemagick
-end


### PR DESCRIPTION
概要
MNiMagickを削除しRMagickを導入することで、本番環境で画像のりサイズ機能が反映されるように変更した